### PR TITLE
Fixed issue with sdk attribute returns None in nested models.

### DIFF
--- a/src/tcgdexsdk/utils.py
+++ b/src/tcgdexsdk/utils.py
@@ -31,6 +31,15 @@ def _urlopen(url: str, _: float) -> str:
 def _from_dict(cls: Type[_TM], data: dict, tcgdex) -> _TM:
     self = from_dict(cls, data)
     self.sdk = tcgdex
+
+    for _, attr_value in self.__dict__.items():
+        if isinstance(attr_value, list):
+            for item in attr_value:
+                if hasattr(item, "sdk"):
+                    item.sdk = tcgdex
+        elif hasattr(attr_value, "sdk"):
+            attr_value.sdk = tcgdex
+
     return self
 
 

--- a/tests/.fixtures/test_get_full_card.yaml
+++ b/tests/.fixtures/test_get_full_card.yaml
@@ -1,0 +1,176 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.tcgdex.net
+      User-Agent:
+      - '@tcgdex/python-sdk@0.1.0'
+    method: GET
+    uri: https://api.tcgdex.net/v2/en/sets/swsh1
+  response:
+    body:
+      string: "{\"cardCount\":{\"firstEd\":0,\"holo\":68,\"normal\":148,\"official\":202,\"reverse\":164,\"total\":216},\"cards\":[{\"id\":\"swsh1-1\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/1\",\"localId\":\"1\",\"name\":\"Celebi
+        V\"},{\"id\":\"swsh1-2\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/2\",\"localId\":\"2\",\"name\":\"Roselia\"},{\"id\":\"swsh1-3\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/3\",\"localId\":\"3\",\"name\":\"Roselia\"},{\"id\":\"swsh1-4\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/4\",\"localId\":\"4\",\"name\":\"Roserade\"},{\"id\":\"swsh1-5\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/5\",\"localId\":\"5\",\"name\":\"Cottonee\"},{\"id\":\"swsh1-6\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/6\",\"localId\":\"6\",\"name\":\"Whimsicott\"},{\"id\":\"swsh1-7\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/7\",\"localId\":\"7\",\"name\":\"Maractus\"},{\"id\":\"swsh1-8\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/8\",\"localId\":\"8\",\"name\":\"Durant\"},{\"id\":\"swsh1-9\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/9\",\"localId\":\"9\",\"name\":\"Dhelmise
+        V\"},{\"id\":\"swsh1-10\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/10\",\"localId\":\"10\",\"name\":\"Grookey\"},{\"id\":\"swsh1-11\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/11\",\"localId\":\"11\",\"name\":\"Grookey\"},{\"id\":\"swsh1-12\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/12\",\"localId\":\"12\",\"name\":\"Thwackey\"},{\"id\":\"swsh1-13\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/13\",\"localId\":\"13\",\"name\":\"Thwackey\"},{\"id\":\"swsh1-14\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/14\",\"localId\":\"14\",\"name\":\"Rillaboom\"},{\"id\":\"swsh1-15\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/15\",\"localId\":\"15\",\"name\":\"Rillaboom\"},{\"id\":\"swsh1-16\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/16\",\"localId\":\"16\",\"name\":\"Blipbug\"},{\"id\":\"swsh1-17\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/17\",\"localId\":\"17\",\"name\":\"Blipbug\"},{\"id\":\"swsh1-18\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/18\",\"localId\":\"18\",\"name\":\"Dottler\"},{\"id\":\"swsh1-19\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/19\",\"localId\":\"19\",\"name\":\"Orbeetle\"},{\"id\":\"swsh1-20\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/20\",\"localId\":\"20\",\"name\":\"Gossifleur\"},{\"id\":\"swsh1-21\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/21\",\"localId\":\"21\",\"name\":\"Eldegoss\"},{\"id\":\"swsh1-22\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/22\",\"localId\":\"22\",\"name\":\"Vulpix\"},{\"id\":\"swsh1-23\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/23\",\"localId\":\"23\",\"name\":\"Ninetales\"},{\"id\":\"swsh1-24\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/24\",\"localId\":\"24\",\"name\":\"Torkoal
+        V\"},{\"id\":\"swsh1-25\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/25\",\"localId\":\"25\",\"name\":\"Victini
+        V\"},{\"id\":\"swsh1-26\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/26\",\"localId\":\"26\",\"name\":\"Heatmor\"},{\"id\":\"swsh1-27\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/27\",\"localId\":\"27\",\"name\":\"Salandit\"},{\"id\":\"swsh1-28\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/28\",\"localId\":\"28\",\"name\":\"Salazzle\"},{\"id\":\"swsh1-29\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/29\",\"localId\":\"29\",\"name\":\"Turtonator\"},{\"id\":\"swsh1-30\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/30\",\"localId\":\"30\",\"name\":\"Scorbunny\"},{\"id\":\"swsh1-31\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/31\",\"localId\":\"31\",\"name\":\"Scorbunny\"},{\"id\":\"swsh1-32\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/32\",\"localId\":\"32\",\"name\":\"Raboot\"},{\"id\":\"swsh1-33\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/33\",\"localId\":\"33\",\"name\":\"Raboot\"},{\"id\":\"swsh1-34\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/34\",\"localId\":\"34\",\"name\":\"Cinderace\"},{\"id\":\"swsh1-35\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/35\",\"localId\":\"35\",\"name\":\"Cinderace\"},{\"id\":\"swsh1-36\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/36\",\"localId\":\"36\",\"name\":\"Cinderace\"},{\"id\":\"swsh1-37\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/37\",\"localId\":\"37\",\"name\":\"Sizzlipede\"},{\"id\":\"swsh1-38\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/38\",\"localId\":\"38\",\"name\":\"Sizzlipede\"},{\"id\":\"swsh1-39\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/39\",\"localId\":\"39\",\"name\":\"Centiskorch\"},{\"id\":\"swsh1-40\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/40\",\"localId\":\"40\",\"name\":\"Shellder\"},{\"id\":\"swsh1-41\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/41\",\"localId\":\"41\",\"name\":\"Cloyster\"},{\"id\":\"swsh1-42\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/42\",\"localId\":\"42\",\"name\":\"Krabby\"},{\"id\":\"swsh1-43\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/43\",\"localId\":\"43\",\"name\":\"Krabby\"},{\"id\":\"swsh1-44\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/44\",\"localId\":\"44\",\"name\":\"Kingler\"},{\"id\":\"swsh1-45\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/45\",\"localId\":\"45\",\"name\":\"Goldeen\"},{\"id\":\"swsh1-46\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/46\",\"localId\":\"46\",\"name\":\"Goldeen\"},{\"id\":\"swsh1-47\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/47\",\"localId\":\"47\",\"name\":\"Seaking\"},{\"id\":\"swsh1-48\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/48\",\"localId\":\"48\",\"name\":\"Lapras\"},{\"id\":\"swsh1-49\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/49\",\"localId\":\"49\",\"name\":\"Lapras
+        V\"},{\"id\":\"swsh1-50\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/50\",\"localId\":\"50\",\"name\":\"Lapras
+        VMAX\"},{\"id\":\"swsh1-51\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/51\",\"localId\":\"51\",\"name\":\"Qwilfish\"},{\"id\":\"swsh1-52\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/52\",\"localId\":\"52\",\"name\":\"Mantine\"},{\"id\":\"swsh1-53\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/53\",\"localId\":\"53\",\"name\":\"Keldeo
+        V\"},{\"id\":\"swsh1-54\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/54\",\"localId\":\"54\",\"name\":\"Sobble\"},{\"id\":\"swsh1-55\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/55\",\"localId\":\"55\",\"name\":\"Sobble\"},{\"id\":\"swsh1-56\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/56\",\"localId\":\"56\",\"name\":\"Drizzile\"},{\"id\":\"swsh1-57\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/57\",\"localId\":\"57\",\"name\":\"Drizzile\"},{\"id\":\"swsh1-58\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/58\",\"localId\":\"58\",\"name\":\"Inteleon\"},{\"id\":\"swsh1-59\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/59\",\"localId\":\"59\",\"name\":\"Inteleon\"},{\"id\":\"swsh1-60\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/60\",\"localId\":\"60\",\"name\":\"Chewtle\"},{\"id\":\"swsh1-61\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/61\",\"localId\":\"61\",\"name\":\"Drednaw\"},{\"id\":\"swsh1-62\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/62\",\"localId\":\"62\",\"name\":\"Cramorant\"},{\"id\":\"swsh1-63\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/63\",\"localId\":\"63\",\"name\":\"Snom\"},{\"id\":\"swsh1-64\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/64\",\"localId\":\"64\",\"name\":\"Frosmoth\"},{\"id\":\"swsh1-65\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/65\",\"localId\":\"65\",\"name\":\"Pikachu\"},{\"id\":\"swsh1-66\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/66\",\"localId\":\"66\",\"name\":\"Raichu\"},{\"id\":\"swsh1-67\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/67\",\"localId\":\"67\",\"name\":\"Chinchou\"},{\"id\":\"swsh1-68\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/68\",\"localId\":\"68\",\"name\":\"Chinchou\"},{\"id\":\"swsh1-69\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/69\",\"localId\":\"69\",\"name\":\"Lanturn\"},{\"id\":\"swsh1-70\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/70\",\"localId\":\"70\",\"name\":\"Joltik\"},{\"id\":\"swsh1-71\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/71\",\"localId\":\"71\",\"name\":\"Galvantula\"},{\"id\":\"swsh1-72\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/72\",\"localId\":\"72\",\"name\":\"Tapu
+        Koko V\"},{\"id\":\"swsh1-73\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/73\",\"localId\":\"73\",\"name\":\"Yamper\"},{\"id\":\"swsh1-74\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/74\",\"localId\":\"74\",\"name\":\"Yamper\"},{\"id\":\"swsh1-75\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/75\",\"localId\":\"75\",\"name\":\"Boltund\"},{\"id\":\"swsh1-76\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/76\",\"localId\":\"76\",\"name\":\"Boltund\"},{\"id\":\"swsh1-77\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/77\",\"localId\":\"77\",\"name\":\"Pincurchin\"},{\"id\":\"swsh1-78\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/78\",\"localId\":\"78\",\"name\":\"Morpeko\"},{\"id\":\"swsh1-79\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/79\",\"localId\":\"79\",\"name\":\"Morpeko
+        V\"},{\"id\":\"swsh1-80\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/80\",\"localId\":\"80\",\"name\":\"Morpeko
+        VMAX\"},{\"id\":\"swsh1-81\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/81\",\"localId\":\"81\",\"name\":\"Galarian
+        Ponyta\"},{\"id\":\"swsh1-82\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/82\",\"localId\":\"82\",\"name\":\"Galarian
+        Rapidash\"},{\"id\":\"swsh1-83\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/83\",\"localId\":\"83\",\"name\":\"Gastly\"},{\"id\":\"swsh1-84\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/84\",\"localId\":\"84\",\"name\":\"Haunter\"},{\"id\":\"swsh1-85\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/85\",\"localId\":\"85\",\"name\":\"Gengar\"},{\"id\":\"swsh1-86\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/86\",\"localId\":\"86\",\"name\":\"Wobbuffet
+        V\"},{\"id\":\"swsh1-87\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/87\",\"localId\":\"87\",\"name\":\"Munna\"},{\"id\":\"swsh1-88\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/88\",\"localId\":\"88\",\"name\":\"Musharna\"},{\"id\":\"swsh1-89\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/89\",\"localId\":\"89\",\"name\":\"Sinistea\"},{\"id\":\"swsh1-90\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/90\",\"localId\":\"90\",\"name\":\"Polteageist\"},{\"id\":\"swsh1-91\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/91\",\"localId\":\"91\",\"name\":\"Indeedee
+        V\"},{\"id\":\"swsh1-92\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/92\",\"localId\":\"92\",\"name\":\"Diglett\"},{\"id\":\"swsh1-93\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/93\",\"localId\":\"93\",\"name\":\"Dugtrio\"},{\"id\":\"swsh1-94\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/94\",\"localId\":\"94\",\"name\":\"Hitmonlee\"},{\"id\":\"swsh1-95\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/95\",\"localId\":\"95\",\"name\":\"Hitmonchan\"},{\"id\":\"swsh1-96\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/96\",\"localId\":\"96\",\"name\":\"Rhyhorn\"},{\"id\":\"swsh1-97\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/97\",\"localId\":\"97\",\"name\":\"Rhyhorn\"},{\"id\":\"swsh1-98\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/98\",\"localId\":\"98\",\"name\":\"Rhydon\"},{\"id\":\"swsh1-99\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/99\",\"localId\":\"99\",\"name\":\"Rhyperior\"},{\"id\":\"swsh1-100\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/100\",\"localId\":\"100\",\"name\":\"Sudowoodo\"},{\"id\":\"swsh1-101\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/101\",\"localId\":\"101\",\"name\":\"Baltoy\"},{\"id\":\"swsh1-102\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/102\",\"localId\":\"102\",\"name\":\"Baltoy\"},{\"id\":\"swsh1-103\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/103\",\"localId\":\"103\",\"name\":\"Claydol\"},{\"id\":\"swsh1-104\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/104\",\"localId\":\"104\",\"name\":\"Regirock
+        V\"},{\"id\":\"swsh1-105\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/105\",\"localId\":\"105\",\"name\":\"Mudbray\"},{\"id\":\"swsh1-106\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/106\",\"localId\":\"106\",\"name\":\"Mudsdale\"},{\"id\":\"swsh1-107\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/107\",\"localId\":\"107\",\"name\":\"Silicobra\"},{\"id\":\"swsh1-108\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/108\",\"localId\":\"108\",\"name\":\"Silicobra\"},{\"id\":\"swsh1-109\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/109\",\"localId\":\"109\",\"name\":\"Sandaconda\"},{\"id\":\"swsh1-110\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/110\",\"localId\":\"110\",\"name\":\"Sandaconda\"},{\"id\":\"swsh1-111\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/111\",\"localId\":\"111\",\"name\":\"Clobbopus\"},{\"id\":\"swsh1-112\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/112\",\"localId\":\"112\",\"name\":\"Clobbopus\"},{\"id\":\"swsh1-113\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/113\",\"localId\":\"113\",\"name\":\"Grapploct\"},{\"id\":\"swsh1-114\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/114\",\"localId\":\"114\",\"name\":\"Stonjourner\"},{\"id\":\"swsh1-115\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/115\",\"localId\":\"115\",\"name\":\"Stonjourner
+        V\"},{\"id\":\"swsh1-116\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/116\",\"localId\":\"116\",\"name\":\"Stonjourner
+        VMAX\"},{\"id\":\"swsh1-117\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/117\",\"localId\":\"117\",\"name\":\"Galarian
+        Zigzagoon\"},{\"id\":\"swsh1-118\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/118\",\"localId\":\"118\",\"name\":\"Galarian
+        Linoone\"},{\"id\":\"swsh1-119\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/119\",\"localId\":\"119\",\"name\":\"Galarian
+        Obstagoon\"},{\"id\":\"swsh1-120\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/120\",\"localId\":\"120\",\"name\":\"Sableye
+        V\"},{\"id\":\"swsh1-121\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/121\",\"localId\":\"121\",\"name\":\"Skorupi\"},{\"id\":\"swsh1-122\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/122\",\"localId\":\"122\",\"name\":\"Drapion\"},{\"id\":\"swsh1-123\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/123\",\"localId\":\"123\",\"name\":\"Croagunk\"},{\"id\":\"swsh1-124\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/124\",\"localId\":\"124\",\"name\":\"Toxicroak\"},{\"id\":\"swsh1-125\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/125\",\"localId\":\"125\",\"name\":\"Nickit\"},{\"id\":\"swsh1-126\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/126\",\"localId\":\"126\",\"name\":\"Thievul\"},{\"id\":\"swsh1-127\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/127\",\"localId\":\"127\",\"name\":\"Galarian
+        Meowth\"},{\"id\":\"swsh1-128\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/128\",\"localId\":\"128\",\"name\":\"Galarian
+        Perrserker\"},{\"id\":\"swsh1-129\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/129\",\"localId\":\"129\",\"name\":\"Mawile\"},{\"id\":\"swsh1-130\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/130\",\"localId\":\"130\",\"name\":\"Ferroseed\"},{\"id\":\"swsh1-131\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/131\",\"localId\":\"131\",\"name\":\"Ferrothorn\"},{\"id\":\"swsh1-132\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/132\",\"localId\":\"132\",\"name\":\"Galarian
+        Stunfisk\"},{\"id\":\"swsh1-133\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/133\",\"localId\":\"133\",\"name\":\"Pawniard\"},{\"id\":\"swsh1-134\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/134\",\"localId\":\"134\",\"name\":\"Bisharp\"},{\"id\":\"swsh1-135\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/135\",\"localId\":\"135\",\"name\":\"Corviknight\"},{\"id\":\"swsh1-136\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/136\",\"localId\":\"136\",\"name\":\"Cufant\"},{\"id\":\"swsh1-137\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/137\",\"localId\":\"137\",\"name\":\"Copperajah\"},{\"id\":\"swsh1-138\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/138\",\"localId\":\"138\",\"name\":\"Zacian
+        V\"},{\"id\":\"swsh1-139\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/139\",\"localId\":\"139\",\"name\":\"Zamazenta
+        V\"},{\"id\":\"swsh1-140\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/140\",\"localId\":\"140\",\"name\":\"Snorlax\"},{\"id\":\"swsh1-141\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/141\",\"localId\":\"141\",\"name\":\"Snorlax
+        V\"},{\"id\":\"swsh1-142\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/142\",\"localId\":\"142\",\"name\":\"Snorlax
+        VMAX\"},{\"id\":\"swsh1-143\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/143\",\"localId\":\"143\",\"name\":\"Hoothoot\"},{\"id\":\"swsh1-144\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/144\",\"localId\":\"144\",\"name\":\"Noctowl\"},{\"id\":\"swsh1-145\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/145\",\"localId\":\"145\",\"name\":\"Minccino\"},{\"id\":\"swsh1-146\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/146\",\"localId\":\"146\",\"name\":\"Minccino\"},{\"id\":\"swsh1-147\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/147\",\"localId\":\"147\",\"name\":\"Cinccino\"},{\"id\":\"swsh1-148\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/148\",\"localId\":\"148\",\"name\":\"Oranguru\"},{\"id\":\"swsh1-149\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/149\",\"localId\":\"149\",\"name\":\"Drampa\"},{\"id\":\"swsh1-150\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/150\",\"localId\":\"150\",\"name\":\"Rookidee\"},{\"id\":\"swsh1-151\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/151\",\"localId\":\"151\",\"name\":\"Corvisquire\"},{\"id\":\"swsh1-152\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/152\",\"localId\":\"152\",\"name\":\"Wooloo\"},{\"id\":\"swsh1-153\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/153\",\"localId\":\"153\",\"name\":\"Wooloo\"},{\"id\":\"swsh1-154\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/154\",\"localId\":\"154\",\"name\":\"Dubwool\"},{\"id\":\"swsh1-155\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/155\",\"localId\":\"155\",\"name\":\"Cramorant
+        V\"},{\"id\":\"swsh1-156\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/156\",\"localId\":\"156\",\"name\":\"Air
+        Balloon\"},{\"id\":\"swsh1-157\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/157\",\"localId\":\"157\",\"name\":\"Bede\"},{\"id\":\"swsh1-158\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/158\",\"localId\":\"158\",\"name\":\"Big
+        Charm\"},{\"id\":\"swsh1-159\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/159\",\"localId\":\"159\",\"name\":\"Crushing
+        Hammer\"},{\"id\":\"swsh1-160\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/160\",\"localId\":\"160\",\"name\":\"Energy
+        Retrieval\"},{\"id\":\"swsh1-161\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/161\",\"localId\":\"161\",\"name\":\"Energy
+        Search\"},{\"id\":\"swsh1-162\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/162\",\"localId\":\"162\",\"name\":\"Energy
+        Switch\"},{\"id\":\"swsh1-163\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/163\",\"localId\":\"163\",\"name\":\"Evolution
+        Incense\"},{\"id\":\"swsh1-164\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/164\",\"localId\":\"164\",\"name\":\"Great
+        Ball\"},{\"id\":\"swsh1-165\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/165\",\"localId\":\"165\",\"name\":\"Hop\"},{\"id\":\"swsh1-166\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/166\",\"localId\":\"166\",\"name\":\"Hyper
+        Potion\"},{\"id\":\"swsh1-167\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/167\",\"localId\":\"167\",\"name\":\"Lucky
+        Egg\"},{\"id\":\"swsh1-168\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/168\",\"localId\":\"168\",\"name\":\"Lum
+        Berry\"},{\"id\":\"swsh1-169\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/169\",\"localId\":\"169\",\"name\":\"Marnie\"},{\"id\":\"swsh1-170\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/170\",\"localId\":\"170\",\"name\":\"Metal
+        Saucer\"},{\"id\":\"swsh1-171\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/171\",\"localId\":\"171\",\"name\":\"Ordinary
+        Rod\"},{\"id\":\"swsh1-172\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/172\",\"localId\":\"172\",\"name\":\"Pal
+        Pad\"},{\"id\":\"swsh1-173\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/173\",\"localId\":\"173\",\"name\":\"Pok\xE9
+        Kid\"},{\"id\":\"swsh1-174\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/174\",\"localId\":\"174\",\"name\":\"Pok\xE9gear
+        3.0\"},{\"id\":\"swsh1-175\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/175\",\"localId\":\"175\",\"name\":\"Pok\xE9mon
+        Catcher\"},{\"id\":\"swsh1-176\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/176\",\"localId\":\"176\",\"name\":\"Pok\xE9mon
+        Center Lady\"},{\"id\":\"swsh1-177\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/177\",\"localId\":\"177\",\"name\":\"Potion\"},{\"id\":\"swsh1-178\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/178\",\"localId\":\"178\",\"name\":\"Professor's
+        Research (Professor Magnolia)\"},{\"id\":\"swsh1-179\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/179\",\"localId\":\"179\",\"name\":\"Quick
+        Ball\"},{\"id\":\"swsh1-180\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/180\",\"localId\":\"180\",\"name\":\"Rare
+        Candy\"},{\"id\":\"swsh1-181\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/181\",\"localId\":\"181\",\"name\":\"Rotom
+        Bike\"},{\"id\":\"swsh1-182\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/182\",\"localId\":\"182\",\"name\":\"Sitrus
+        Berry\"},{\"id\":\"swsh1-183\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/183\",\"localId\":\"183\",\"name\":\"Switch\"},{\"id\":\"swsh1-184\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/184\",\"localId\":\"184\",\"name\":\"Team
+        Yell Grunt\"},{\"id\":\"swsh1-185\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/185\",\"localId\":\"185\",\"name\":\"Vitality
+        Band\"},{\"id\":\"swsh1-186\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/186\",\"localId\":\"186\",\"name\":\"Aurora
+        Energy\"},{\"id\":\"swsh1-187\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/187\",\"localId\":\"187\",\"name\":\"Dhelmise
+        V\"},{\"id\":\"swsh1-188\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/188\",\"localId\":\"188\",\"name\":\"Torkoal
+        V\"},{\"id\":\"swsh1-189\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/189\",\"localId\":\"189\",\"name\":\"Lapras
+        V\"},{\"id\":\"swsh1-190\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/190\",\"localId\":\"190\",\"name\":\"Morpeko
+        V\"},{\"id\":\"swsh1-191\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/191\",\"localId\":\"191\",\"name\":\"Wobbuffet
+        V\"},{\"id\":\"swsh1-192\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/192\",\"localId\":\"192\",\"name\":\"Indeedee
+        V\"},{\"id\":\"swsh1-193\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/193\",\"localId\":\"193\",\"name\":\"Stonjourner
+        V\"},{\"id\":\"swsh1-194\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/194\",\"localId\":\"194\",\"name\":\"Sableye
+        V\"},{\"id\":\"swsh1-195\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/195\",\"localId\":\"195\",\"name\":\"Zacian
+        V\"},{\"id\":\"swsh1-196\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/196\",\"localId\":\"196\",\"name\":\"Zamazenta
+        V\"},{\"id\":\"swsh1-197\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/197\",\"localId\":\"197\",\"name\":\"Snorlax
+        V\"},{\"id\":\"swsh1-198\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/198\",\"localId\":\"198\",\"name\":\"Cramorant
+        V\"},{\"id\":\"swsh1-199\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/199\",\"localId\":\"199\",\"name\":\"Bede\"},{\"id\":\"swsh1-200\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/200\",\"localId\":\"200\",\"name\":\"Marnie\"},{\"id\":\"swsh1-201\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/201\",\"localId\":\"201\",\"name\":\"Professor's
+        Research (Professor Magnolia)\"},{\"id\":\"swsh1-202\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/202\",\"localId\":\"202\",\"name\":\"Team
+        Yell Grunt\"},{\"id\":\"swsh1-203\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/203\",\"localId\":\"203\",\"name\":\"Lapras
+        VMAX\"},{\"id\":\"swsh1-204\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/204\",\"localId\":\"204\",\"name\":\"Morpeko
+        VMAX\"},{\"id\":\"swsh1-205\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/205\",\"localId\":\"205\",\"name\":\"Stonjourner
+        VMAX\"},{\"id\":\"swsh1-206\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/206\",\"localId\":\"206\",\"name\":\"Snorlax
+        VMAX\"},{\"id\":\"swsh1-207\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/207\",\"localId\":\"207\",\"name\":\"Bede\"},{\"id\":\"swsh1-208\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/208\",\"localId\":\"208\",\"name\":\"Marnie\"},{\"id\":\"swsh1-209\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/209\",\"localId\":\"209\",\"name\":\"Professor's
+        Research (Professor Magnolia)\"},{\"id\":\"swsh1-210\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/210\",\"localId\":\"210\",\"name\":\"Team
+        Yell Grunt\"},{\"id\":\"swsh1-211\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/211\",\"localId\":\"211\",\"name\":\"Zacian
+        V\"},{\"id\":\"swsh1-212\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/212\",\"localId\":\"212\",\"name\":\"Zamazenta
+        V\"},{\"id\":\"swsh1-213\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/213\",\"localId\":\"213\",\"name\":\"Air
+        Balloon\"},{\"id\":\"swsh1-214\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/214\",\"localId\":\"214\",\"name\":\"Metal
+        Saucer\"},{\"id\":\"swsh1-215\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/215\",\"localId\":\"215\",\"name\":\"Ordinary
+        Rod\"},{\"id\":\"swsh1-216\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/216\",\"localId\":\"216\",\"name\":\"Quick
+        Ball\"}],\"id\":\"swsh1\",\"legal\":{\"expanded\":true,\"standard\":false},\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh1/logo\",\"name\":\"Sword
+        & Shield\",\"releaseDate\":\"2020-02-07\",\"serie\":{\"id\":\"swsh\",\"name\":\"Sword
+        & Shield\"},\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh1/symbol\",\"tcgOnline\":\"SSH\",\"abbreviation\":{\"official\":\"SSH\"}}"
+    headers:
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Length:
+      - '23544'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Nov 2024 02:05:30 GMT
+      Etag:
+      - W/"5bf8-M/HW5upyYJm17bcz3YSh+9hUkAI"
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.tcgdex.net
+      User-Agent:
+      - '@tcgdex/python-sdk@0.1.0'
+    method: GET
+    uri: https://api.tcgdex.net/v2/en/cards/swsh1-1
+  response:
+    body:
+      string: "{\"category\":\"Pokemon\",\"id\":\"swsh1-1\",\"illustrator\":\"PLANETA
+        Igarashi\",\"image\":\"https://assets.tcgdex.net/en/swsh/swsh1/1\",\"localId\":\"1\",\"name\":\"Celebi
+        V\",\"rarity\":\"Holo Rare V\",\"set\":{\"cardCount\":{\"official\":202,\"total\":216},\"id\":\"swsh1\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh1/logo\",\"name\":\"Sword
+        & Shield\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh1/symbol\"},\"variants\":{\"firstEdition\":false,\"holo\":true,\"normal\":false,\"reverse\":false,\"wPromo\":false},\"dexId\":[251],\"hp\":180,\"types\":[\"Grass\"],\"stage\":\"Basic\",\"suffix\":\"V\",\"attacks\":[{\"cost\":[\"Grass\"],\"name\":\"Find
+        a Friend\",\"effect\":\"Search your deck for up to 2 Pok\xE9mon, reveal them,
+        and put them into your hand. Then, shuffle your deck.\"},{\"cost\":[\"Grass\",\"Colorless\"],\"name\":\"Line
+        Force\",\"effect\":\"This attack does 20 more damage for each of your Benched
+        Pok\xE9mon.\",\"damage\":\"50+\"}],\"weaknesses\":[{\"type\":\"Fire\",\"value\":\"\xD72\"}],\"retreat\":1,\"regulationMark\":\"D\",\"legal\":{\"standard\":false,\"expanded\":true},\"updated\":\"2023-12-27T19:30:08+01:00\"}"
+    headers:
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Length:
+      - '1013'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Nov 2024 02:05:32 GMT
+      Etag:
+      - W/"3f5-B9jXLvyjQrXky5c59gONeTcRsb8"
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/.fixtures/test_get_full_serie.yaml
+++ b/tests/.fixtures/test_get_full_serie.yaml
@@ -1,0 +1,101 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.tcgdex.net
+      User-Agent:
+      - '@tcgdex/python-sdk@0.1.0'
+    method: GET
+    uri: https://api.tcgdex.net/v2/en/series
+  response:
+    body:
+      string: "[{\"id\":\"base\",\"name\":\"Base\",\"logo\":\"https://assets.tcgdex.net/en/base/base1/logo\"},{\"id\":\"misc\",\"name\":\"Miscellaneous\"},{\"id\":\"gym\",\"name\":\"Gym\",\"logo\":\"https://assets.tcgdex.net/en/gym/gym1/logo\"},{\"id\":\"neo\",\"name\":\"Neo\",\"logo\":\"https://assets.tcgdex.net/en/neo/neo1/logo\"},{\"id\":\"lc\",\"name\":\"Legendary
+        Collection\",\"logo\":\"https://assets.tcgdex.net/en/lc/lc/logo\"},{\"id\":\"ecard\",\"name\":\"E-Card\",\"logo\":\"https://assets.tcgdex.net/en/ecard/ecard1/logo\"},{\"id\":\"ex\",\"name\":\"EX\",\"logo\":\"https://assets.tcgdex.net/en/ex/ex1/logo\"},{\"id\":\"pop\",\"name\":\"POP\",\"logo\":\"https://assets.tcgdex.net/en/pop/np/logo\"},{\"id\":\"tk\",\"name\":\"Trainer
+        kits\"},{\"id\":\"dp\",\"name\":\"Diamond & Pearl\",\"logo\":\"https://assets.tcgdex.net/en/dp/dpp/logo\"},{\"id\":\"pl\",\"name\":\"Platinum\",\"logo\":\"https://assets.tcgdex.net/en/pl/pl1/logo\"},{\"id\":\"hgss\",\"name\":\"HeartGold
+        & SoulSilver\",\"logo\":\"https://assets.tcgdex.net/en/hgss/hgss1/logo\"},{\"id\":\"col\",\"name\":\"Call
+        of Legends\",\"logo\":\"https://assets.tcgdex.net/en/col/col1/logo\"},{\"id\":\"bw\",\"name\":\"Black
+        & White\",\"logo\":\"https://assets.tcgdex.net/en/bw/bw1/logo\"},{\"id\":\"mc\",\"name\":\"McDonald's
+        Collection\"},{\"id\":\"xy\",\"name\":\"XY\",\"logo\":\"https://assets.tcgdex.net/en/xy/xyp/logo\"},{\"id\":\"sm\",\"name\":\"Sun
+        & Moon\",\"logo\":\"https://assets.tcgdex.net/en/sm/smp/logo\"},{\"id\":\"swsh\",\"name\":\"Sword
+        & Shield\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swshp/logo\"},{\"id\":\"sv\",\"name\":\"Scarlet
+        & Violet\",\"logo\":\"https://assets.tcgdex.net/en/sv/sv01/logo\"},{\"id\":\"tcgp\",\"name\":\"Pok\xE9mon
+        TCG Pocket\",\"logo\":\"https://assets.tcgdex.net/en/tcgp/A1/logo\"}]"
+    headers:
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Length:
+      - '1554'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Nov 2024 02:09:48 GMT
+      Etag:
+      - W/"612-P/HRLSr/lTR7aRKVSelPvT6bAKY"
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.tcgdex.net
+      User-Agent:
+      - '@tcgdex/python-sdk@0.1.0'
+    method: GET
+    uri: https://api.tcgdex.net/v2/en/series/base
+  response:
+    body:
+      string: '{"id":"base","logo":"https://assets.tcgdex.net/en/base/base1/logo","name":"Base","sets":[{"cardCount":{"official":102,"total":102},"id":"base1","logo":"https://assets.tcgdex.net/en/base/base1/logo","name":"Base
+        Set"},{"cardCount":{"official":64,"total":64},"id":"base2","logo":"https://assets.tcgdex.net/en/base/base2/logo","name":"Jungle","symbol":"https://assets.tcgdex.net/univ/base/base2/symbol"},{"cardCount":{"official":53,"total":53},"id":"basep","logo":"https://assets.tcgdex.net/en/base/basep/logo","name":"Wizards
+        Black Star Promos","symbol":"https://assets.tcgdex.net/univ/base/basep/symbol"},{"cardCount":{"official":7,"total":7},"id":"wp","name":"W
+        Promotional"},{"cardCount":{"official":62,"total":62},"id":"base3","logo":"https://assets.tcgdex.net/en/base/base3/logo","name":"Fossil","symbol":"https://assets.tcgdex.net/univ/base/base3/symbol"},{"cardCount":{"official":130,"total":130},"id":"base4","logo":"https://assets.tcgdex.net/en/base/base4/logo","name":"Base
+        Set 2","symbol":"https://assets.tcgdex.net/univ/base/base4/symbol"},{"cardCount":{"official":82,"total":83},"id":"base5","logo":"https://assets.tcgdex.net/en/base/base5/logo","name":"Team
+        Rocket","symbol":"https://assets.tcgdex.net/univ/base/base5/symbol"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Length:
+      - '1240'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Nov 2024 02:09:49 GMT
+      Etag:
+      - W/"4d8-M8WkmAvuAHJ0bRwmMDFZCQ0RdSE"
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/.fixtures/test_get_full_set.yaml
+++ b/tests/.fixtures/test_get_full_set.yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.tcgdex.net
+      User-Agent:
+      - '@tcgdex/python-sdk@0.1.0'
+    method: GET
+    uri: https://api.tcgdex.net/v2/en/series/swsh
+  response:
+    body:
+      string: "{\"id\":\"swsh\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swshp/logo\",\"name\":\"Sword
+        & Shield\",\"sets\":[{\"cardCount\":{\"official\":107,\"total\":166},\"id\":\"swshp\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swshp/logo\",\"name\":\"SWSH
+        Black Star Promos\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swshp/symbol\"},{\"cardCount\":{\"official\":202,\"total\":216},\"id\":\"swsh1\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh1/logo\",\"name\":\"Sword
+        & Shield\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh1/symbol\"},{\"cardCount\":{\"official\":192,\"total\":209},\"id\":\"swsh2\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh2/logo\",\"name\":\"Rebel
+        Clash\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh2/symbol\"},{\"cardCount\":{\"official\":189,\"total\":201},\"id\":\"swsh3\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh3/logo\",\"name\":\"Darkness
+        Ablaze\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh3/symbol\"},{\"cardCount\":{\"official\":5,\"total\":5},\"id\":\"fut2020\",\"logo\":\"https://assets.tcgdex.net/en/swsh/fut2020/logo\",\"name\":\"Pok\xE9mon
+        Futsal 2020\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/fut2020/symbol\"},{\"cardCount\":{\"official\":70,\"total\":80},\"id\":\"swsh3.5\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh3.5/logo\",\"name\":\"Champion's
+        Path\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh3.5/symbol\"},{\"cardCount\":{\"official\":185,\"total\":203},\"id\":\"swsh4\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh4/logo\",\"name\":\"Vivid
+        Voltage\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh4/symbol\"},{\"cardCount\":{\"official\":72,\"total\":195},\"id\":\"swsh4.5\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh4.5/logo\",\"name\":\"Shining
+        Fates\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh4.5/symbol\"},{\"cardCount\":{\"official\":163,\"total\":183},\"id\":\"swsh5\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh5/logo\",\"name\":\"Battle
+        Styles\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh5/symbol\"},{\"cardCount\":{\"official\":198,\"total\":233},\"id\":\"swsh6\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh6/logo\",\"name\":\"Chilling
+        Reign\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh6/symbol\"},{\"cardCount\":{\"official\":203,\"total\":237},\"id\":\"swsh7\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh7/logo\",\"name\":\"Evolving
+        Skies\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh7/symbol\"},{\"cardCount\":{\"official\":25,\"total\":51},\"id\":\"cel25\",\"logo\":\"https://assets.tcgdex.net/en/swsh/cel25/logo\",\"name\":\"Celebrations\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/cel25/symbol\"},{\"cardCount\":{\"official\":264,\"total\":284},\"id\":\"swsh8\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh8/logo\",\"name\":\"Fusion
+        Strike\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh8/symbol\"},{\"cardCount\":{\"official\":172,\"total\":216},\"id\":\"swsh9\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh9/logo\",\"name\":\"Brilliant
+        Stars\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh9/symbol\"},{\"cardCount\":{\"official\":189,\"total\":246},\"id\":\"swsh10\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh10/logo\",\"name\":\"Astral
+        Radiance\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh10/symbol\"},{\"cardCount\":{\"official\":78,\"total\":88},\"id\":\"swsh10.5\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh10.5/logo\",\"name\":\"Pok\xE9mon
+        GO\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh10.5/symbol\"},{\"cardCount\":{\"official\":196,\"total\":247},\"id\":\"swsh11\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh11/logo\",\"name\":\"Lost
+        Origin\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh11/symbol\"},{\"cardCount\":{\"official\":195,\"total\":245},\"id\":\"swsh12\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh12/logo\",\"name\":\"Silver
+        Tempest\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh12/symbol\"},{\"cardCount\":{\"official\":159,\"total\":230},\"id\":\"swsh12.5\",\"logo\":\"https://assets.tcgdex.net/en/swsh/swsh12.5/logo\",\"name\":\"Crown
+        Zenith\",\"symbol\":\"https://assets.tcgdex.net/univ/swsh/swsh12.5/symbol\"}]}"
+    headers:
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Length:
+      - '3821'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Nov 2024 02:09:50 GMT
+      Etag:
+      - W/"eed-NQdypzKPHFMtRQvfcaWeUrxG4Qg"
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.tcgdex.net
+      User-Agent:
+      - '@tcgdex/python-sdk@0.1.0'
+    method: GET
+    uri: https://api.tcgdex.net/v2/en/sets/swshp
+  response:
+    body:
+      string: '{"cardCount":{"firstEd":0,"holo":125,"normal":0,"official":107,"reverse":0,"total":166},"cards":[{"id":"swshp-SWSH001","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH001","localId":"SWSH001","name":"Grookey"},{"id":"swshp-SWSH002","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH002","localId":"SWSH002","name":"Scorbunny"},{"id":"swshp-SWSH003","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH003","localId":"SWSH003","name":"Sobble"},{"id":"swshp-SWSH004","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH004","localId":"SWSH004","name":"Meowth
+        V"},{"id":"swshp-SWSH005","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH005","localId":"SWSH005","name":"Meowth
+        VMAX"},{"id":"swshp-SWSH006","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH006","localId":"SWSH006","name":"Rillaboom"},{"id":"swshp-SWSH007","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH007","localId":"SWSH007","name":"Frosmoth"},{"id":"swshp-SWSH008","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH008","localId":"SWSH008","name":"Galarian
+        Perrserker"},{"id":"swshp-SWSH009","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH009","localId":"SWSH009","name":"Cinccino"},{"id":"swshp-SWSH010","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH010","localId":"SWSH010","name":"Gossifleur"},{"id":"swshp-SWSH011","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH011","localId":"SWSH011","name":"Wooloo"},{"id":"swshp-SWSH012","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH012","localId":"SWSH012","name":"Morpeko"},{"id":"swshp-SWSH013","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH013","localId":"SWSH013","name":"Galarian
+        Ponyta"},{"id":"swshp-SWSH014","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH014","localId":"SWSH014","name":"Rillaboom
+        V"},{"id":"swshp-SWSH015","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH015","localId":"SWSH015","name":"Cinderace
+        V"},{"id":"swshp-SWSH016","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH016","localId":"SWSH016","name":"Inteleon
+        V"},{"id":"swshp-SWSH017","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH017","localId":"SWSH017","name":"Toxtricity
+        V"},{"id":"swshp-SWSH018","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH018","localId":"SWSH018","name":"Zacian
+        V"},{"id":"swshp-SWSH019","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH019","localId":"SWSH019","name":"Zamazenta
+        V"},{"id":"swshp-SWSH020","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH020","localId":"SWSH020","name":"Pikachu"},{"id":"swshp-SWSH021","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH021","localId":"SWSH021","name":"Polteageist
+        V"},{"id":"swshp-SWSH022","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH022","localId":"SWSH022","name":"Flapple"},{"id":"swshp-SWSH023","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH023","localId":"SWSH023","name":"Luxray"},{"id":"swshp-SWSH024","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH024","localId":"SWSH024","name":"Coalossal"},{"id":"swshp-SWSH025","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH025","localId":"SWSH025","name":"Garbodor"},{"id":"swshp-SWSH026","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH026","localId":"SWSH026","name":"Mantine"},{"id":"swshp-SWSH027","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH027","localId":"SWSH027","name":"Noctowl"},{"id":"swshp-SWSH028","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH028","localId":"SWSH028","name":"Duraludon"},{"id":"swshp-SWSH029","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH029","localId":"SWSH029","name":"Rayquaza"},{"id":"swshp-SWSH030","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH030","localId":"SWSH030","name":"Copperajah
+        V"},{"id":"swshp-SWSH031","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH031","localId":"SWSH031","name":"Morpeko"},{"id":"swshp-SWSH032","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH032","localId":"SWSH032","name":"Snorlax"},{"id":"swshp-SWSH033","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH033","localId":"SWSH033","name":"Zacian"},{"id":"swshp-SWSH034","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH034","localId":"SWSH034","name":"Zamazenta"},{"id":"swshp-SWSH035","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH035","localId":"SWSH035","name":"Decidueye"},{"id":"swshp-SWSH036","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH036","localId":"SWSH036","name":"Arctozolt"},{"id":"swshp-SWSH037","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH037","localId":"SWSH037","name":"Hydreigon"},{"id":"swshp-SWSH038","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH038","localId":"SWSH038","name":"Kangaskhan"},{"id":"swshp-SWSH039","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH039","localId":"SWSH039","name":"Pikachu"},{"id":"swshp-SWSH040","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH040","localId":"SWSH040","name":"Hatenna"},{"id":"swshp-SWSH041","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH041","localId":"SWSH041","name":"Flareon"},{"id":"swshp-SWSH042","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH042","localId":"SWSH042","name":"Eevee"},{"id":"swshp-SWSH043","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH043","localId":"SWSH043","name":"Galarian
+        Sirfetch''d V"},{"id":"swshp-SWSH044","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH044","localId":"SWSH044","name":"Eternatus
+        V"},{"id":"swshp-SWSH045","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH045","localId":"SWSH045","name":"Eternatus
+        VMAX"},{"id":"swshp-SWSH046","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH046","localId":"SWSH046","name":"Eldegoss"},{"id":"swshp-SWSH047","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH047","localId":"SWSH047","name":"Drednaw"},{"id":"swshp-SWSH048","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH048","localId":"SWSH048","name":"Centiskorch"},{"id":"swshp-SWSH049","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH049","localId":"SWSH049","name":"Dubwool
+        V"},{"id":"swshp-SWSH050","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH050","localId":"SWSH050","name":"Charizard
+        V"},{"id":"swshp-SWSH051","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH051","localId":"SWSH051","name":"Lapras"},{"id":"swshp-SWSH052","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH052","localId":"SWSH052","name":"Gengar"},{"id":"swshp-SWSH053","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH053","localId":"SWSH053","name":"Machamp"},{"id":"swshp-SWSH054","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH054","localId":"SWSH054","name":"Coalossal"},{"id":"swshp-SWSH055","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH055","localId":"SWSH055","name":"Hatterene
+        V"},{"id":"swshp-SWSH056","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH056","localId":"SWSH056","name":"Morpeko
+        V"},{"id":"swshp-SWSH057","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH057","localId":"SWSH057","name":"Grimmsnarl
+        V"},{"id":"swshp-SWSH058","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH058","localId":"SWSH058","name":"Alcremie"},{"id":"swshp-SWSH059","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH059","localId":"SWSH059","name":"Galarian
+        Obstagoon"},{"id":"swshp-SWSH060","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH060","localId":"SWSH060","name":"Duraludon"},{"id":"swshp-SWSH061","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH061","localId":"SWSH061","name":"Pikachu
+        V"},{"id":"swshp-SWSH062","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH062","localId":"SWSH062","name":"Pikachu
+        VMAX"},{"id":"swshp-SWSH063","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH063","localId":"SWSH063","name":"Pikachu
+        V"},{"id":"swshp-SWSH064","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH064","localId":"SWSH064","name":"Eternatus
+        V"},{"id":"swshp-SWSH065","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH065","localId":"SWSH065","name":"Eevee
+        V"},{"id":"swshp-SWSH066","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH066","localId":"SWSH066","name":"Charizard"},{"id":"swshp-SWSH067","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH067","localId":"SWSH067","name":"Donphan"},{"id":"swshp-SWSH068","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH068","localId":"SWSH068","name":"Snorlax"},{"id":"swshp-SWSH069","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH069","localId":"SWSH069","name":"Lugia"},{"id":"swshp-SWSH070","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH070","localId":"SWSH070","name":"Grookey"},{"id":"swshp-SWSH071","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH071","localId":"SWSH071","name":"Scorbunny"},{"id":"swshp-SWSH072","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH072","localId":"SWSH072","name":"Vaporeon"},{"id":"swshp-SWSH073","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH073","localId":"SWSH073","name":"Sobble"},{"id":"swshp-SWSH074","localId":"SWSH074","name":"Special
+        Delivery Pikachu"},{"id":"swshp-SWSH076","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH076","localId":"SWSH076","name":"Zacian
+        V"},{"id":"swshp-SWSH077","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH077","localId":"SWSH077","name":"Zamazenta
+        V"},{"id":"swshp-SWSH078","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH078","localId":"SWSH078","name":"Orbeetle
+        V"},{"id":"swshp-SWSH079","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH079","localId":"SWSH079","name":"Galarian
+        Mr. Rime"},{"id":"swshp-SWSH080","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH080","localId":"SWSH080","name":"Dedenne"},{"id":"swshp-SWSH081","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH081","localId":"SWSH081","name":"Polteageist"},{"id":"swshp-SWSH082","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH082","localId":"SWSH082","name":"Bunnelby"},{"id":"swshp-SWSH083","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH083","localId":"SWSH083","name":"Alakazam
+        V"},{"id":"swshp-SWSH084","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH084","localId":"SWSH084","name":"Eldegoss
+        V"},{"id":"swshp-SWSH085","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH085","localId":"SWSH085","name":"Boltund
+        V"},{"id":"swshp-SWSH086","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH086","localId":"SWSH086","name":"Cramorant
+        V"},{"id":"swshp-SWSH087","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH087","localId":"SWSH087","name":"Eevee
+        VMAX"},{"id":"swshp-SWSH088","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH088","localId":"SWSH088","name":"Cherrim"},{"id":"swshp-SWSH089","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH089","localId":"SWSH089","name":"Octillery"},{"id":"swshp-SWSH090","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH090","localId":"SWSH090","name":"Houndoom"},{"id":"swshp-SWSH091","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH091","localId":"SWSH091","name":"Bronzong"},{"id":"swshp-SWSH092","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH092","localId":"SWSH092","name":"Charmander"},{"id":"swshp-SWSH093","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH093","localId":"SWSH093","name":"Arrokuda"},{"id":"swshp-SWSH094","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH094","localId":"SWSH094","name":"Jolteon"},{"id":"swshp-SWSH095","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH095","localId":"SWSH095","name":"Eevee"},{"id":"swshp-SWSH096","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH096","localId":"SWSH096","name":"Dragapult
+        V"},{"id":"swshp-SWSH097","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH097","localId":"SWSH097","name":"Dragapult
+        VMAX"},{"id":"swshp-SWSH098","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH098","localId":"SWSH098","name":"Crobat
+        V"},{"id":"swshp-SWSH099","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH099","localId":"SWSH099","name":"Crobat
+        VMAX"},{"id":"swshp-SWSH100","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH100","localId":"SWSH100","name":"Venusaur
+        V"},{"id":"swshp-SWSH101","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH101","localId":"SWSH101","name":"Blastoise
+        V"},{"id":"swshp-SWSH102","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH102","localId":"SWSH102","name":"Venusaur
+        VMAX"},{"id":"swshp-SWSH103","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH103","localId":"SWSH103","name":"Blastoise
+        VMAX"},{"id":"swshp-SWSH104","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH104","localId":"SWSH104","name":"Victini
+        V"},{"id":"swshp-SWSH105","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH105","localId":"SWSH105","name":"Gardevoir
+        V"},{"id":"swshp-SWSH106","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH106","localId":"SWSH106","name":"Single
+        Strike Urshifu V"},{"id":"swshp-SWSH107","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH107","localId":"SWSH107","name":"Rapid
+        Strike Urshifu V"},{"id":"swshp-SWSH108","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH108","localId":"SWSH108","name":"Empoleon
+        V"},{"id":"swshp-SWSH109","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH109","localId":"SWSH109","name":"Tyranitar
+        V"},{"id":"swshp-SWSH110","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH110","localId":"SWSH110","name":"Crobat
+        V"},{"id":"swshp-SWSH111","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH111","localId":"SWSH111","name":"Galarian
+        Rapidash V"},{"id":"swshp-SWSH112","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH112","localId":"SWSH112","name":"Cinderace"},{"id":"swshp-SWSH113","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH113","localId":"SWSH113","name":"Inteleon"},{"id":"swshp-SWSH114","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH114","localId":"SWSH114","name":"Cresselia"},{"id":"swshp-SWSH115","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH115","localId":"SWSH115","name":"Passimian"},{"id":"swshp-SWSH116","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH116","localId":"SWSH116","name":"Morpeko"},{"id":"swshp-SWSH117","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH117","localId":"SWSH117","name":"Phanpy"},{"id":"swshp-SWSH118","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH118","localId":"SWSH118","name":"Eevee"},{"id":"swshp-SWSH119","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH119","localId":"SWSH119","name":"Snorlax"},{"id":"swshp-SWSH120","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH120","localId":"SWSH120","name":"Marnie"},{"id":"swshp-SWSH121","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH121","localId":"SWSH121","name":"Marnie"},{"id":"swshp-SWSH122","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH122","localId":"SWSH122","name":"Flaaffy"},{"id":"swshp-SWSH123","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH123","localId":"SWSH123","name":"Galarian
+        Articuno"},{"id":"swshp-SWSH124","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH124","localId":"SWSH124","name":"Galarian
+        Zapdos"},{"id":"swshp-SWSH125","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH125","localId":"SWSH125","name":"Galarian
+        Moltres"},{"id":"swshp-SWSH126","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH126","localId":"SWSH126","name":"Galarian
+        Slowpoke"},{"id":"swshp-SWSH127","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH127","localId":"SWSH127","name":"Eevee"},{"id":"swshp-SWSH128","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH128","localId":"SWSH128","name":"Eiscue"},{"id":"swshp-SWSH129","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH129","localId":"SWSH129","name":"Umbreon"},{"id":"swshp-SWSH130","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH130","localId":"SWSH130","name":"Ice
+        Rider Calyrex V"},{"id":"swshp-SWSH131","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH131","localId":"SWSH131","name":"Shadow
+        Rider Calyrex V"},{"id":"swshp-SWSH132","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH132","localId":"SWSH132","name":"Dragapult"},{"id":"swshp-SWSH133","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH133","localId":"SWSH133","name":"Lance''s
+        Charizard V"},{"id":"swshp-SWSH134","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH134","localId":"SWSH134","name":"Dark
+        Sylveon V"},{"id":"swshp-SWSH135","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH135","localId":"SWSH135","name":"Zacian
+        LV.X"},{"id":"swshp-SWSH136","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH136","localId":"SWSH136","name":"Mimikyu"},{"id":"swshp-SWSH137","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH137","localId":"SWSH137","name":"Light
+        Toxtricity"},{"id":"swshp-SWSH138","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH138","localId":"SWSH138","name":"Hydreigon
+        C lv.61"},{"id":"swshp-SWSH139","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH139","localId":"SWSH139","name":"Pikachu
+        V-UNION"},{"id":"swshp-SWSH140","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH140","localId":"SWSH140","name":"Pikachu
+        V-UNION"},{"id":"swshp-SWSH141","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH141","localId":"SWSH141","name":"Pikachu
+        V-UNION"},{"id":"swshp-SWSH142","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH142","localId":"SWSH142","name":"Pikachu
+        V-UNION"},{"id":"swshp-SWSH143","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH143","localId":"SWSH143","name":"Pikachu
+        V"},{"id":"swshp-SWSH144","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH144","localId":"SWSH144","name":"Greninja
+        Star"},{"id":"swshp-SWSH145","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH145","localId":"SWSH145","name":"Pikachu
+        V"},{"id":"swshp-SWSH146","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH146","localId":"SWSH146","name":"Poke
+        Ball"},{"id":"swshp-SWSH147","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH147","localId":"SWSH147","name":"Rayquaza
+        V"},{"id":"swshp-SWSH148","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH148","localId":"SWSH148","name":"Noivern
+        V"},{"id":"swshp-SWSH149","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH149","localId":"SWSH149","name":"Flareon
+        V"},{"id":"swshp-SWSH150","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH150","localId":"SWSH150","name":"Vaporeon
+        V"},{"id":"swshp-SWSH151","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH151","localId":"SWSH151","name":"Jolteon
+        V"},{"id":"swshp-SWSH154","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH154","localId":"SWSH154","name":"Dragonite
+        V"},{"id":"swshp-SWSH155","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH155","localId":"SWSH155","name":"Greninja
+        V-UNION"},{"id":"swshp-SWSH156","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH156","localId":"SWSH156","name":"Greninja
+        V-UNION"},{"id":"swshp-SWSH157","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH157","localId":"SWSH157","name":"Greninja
+        V-UNION"},{"id":"swshp-SWSH158","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH158","localId":"SWSH158","name":"Greninja
+        V-UNION"},{"id":"swshp-SWSH159","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH159","localId":"SWSH159","name":"Mewtwo
+        V-UNION"},{"id":"swshp-SWSH160","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH160","localId":"SWSH160","name":"Mewtwo
+        V-UNION"},{"id":"swshp-SWSH161","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH161","localId":"SWSH161","name":"Mewtwo
+        V-UNION"},{"id":"swshp-SWSH162","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH162","localId":"SWSH162","name":"Mewtwo
+        V-UNION"},{"id":"swshp-SWSH163","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH163","localId":"SWSH163","name":"Zacian
+        V-UNION"},{"id":"swshp-SWSH164","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH164","localId":"SWSH164","name":"Zacian
+        V-UNION"},{"id":"swshp-SWSH165","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH165","localId":"SWSH165","name":"Zacian
+        V-UNION"},{"id":"swshp-SWSH166","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH166","localId":"SWSH166","name":"Zacian
+        V-UNION"},{"id":"swshp-SWSH167","image":"https://assets.tcgdex.net/en/swsh/swshp/SWSH167","localId":"SWSH167","name":"Professor
+        Burnet"},{"id":"swshp-SWSH177","localId":"SWSH177","name":"Special Delivery
+        Bidoof"},{"id":"swshp-SWSH178","localId":"SWSH178","name":"Professor''s Research"}],"id":"swshp","legal":{"expanded":true,"standard":false},"logo":"https://assets.tcgdex.net/en/swsh/swshp/logo","name":"SWSH
+        Black Star Promos","releaseDate":"2019-11-15","serie":{"id":"swsh","name":"Sword
+        & Shield"},"symbol":"https://assets.tcgdex.net/univ/swsh/swshp/symbol"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+      Alt-Svc:
+      - h3=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - close
+      Content-Length:
+      - '20391'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 28 Nov 2024 02:09:51 GMT
+      Etag:
+      - W/"4fa7-CQVjHAKW/ESj+Jy9xNoWKeEEsT0"
+      X-Powered-By:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -42,6 +42,14 @@ class APITest(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(res, Card)
 
     @_use_cassette
+    async def test_get_full_card(self):
+        set = await self.api.set.get("swsh1")
+        card = set.cards[0]
+        self.assertIsInstance(card.sdk, TCGdex)
+        card_full = await card.get_full_card()
+        self.assertIsInstance(card_full, Card)
+
+    @_use_cassette
     async def test_set_resume(self):
         res = await self.api.set.list()
         self.assertIsInstance(res[0], SetResume)
@@ -52,6 +60,14 @@ class APITest(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(res, Set)
 
     @_use_cassette
+    async def test_get_full_set(self):
+        serie = await self.api.serie.get("swsh")
+        set = serie.sets[0]
+        self.assertIsInstance(set.sdk, TCGdex)
+        set_full = await set.get_full_set()
+        self.assertIsInstance(set_full, Set)
+
+    @_use_cassette
     async def test_serie_resume(self):
         res = await self.api.serie.list()
         self.assertIsInstance(res[0], SerieResume)
@@ -60,6 +76,14 @@ class APITest(unittest.IsolatedAsyncioTestCase):
     async def test_serie(self):
         res = await self.api.serie.get("swsh")
         self.assertIsInstance(res, Serie)
+
+    @_use_cassette
+    async def test_get_full_serie(self):
+        series = await self.api.serie.list()
+        serie = series[0]
+        self.assertIsInstance(serie.sdk, TCGdex)
+        serie_full = await serie.get_full_serie()
+        self.assertIsInstance(serie_full, Serie)
 
     @_use_cassette
     async def test_variant_list(self):


### PR DESCRIPTION
Whenever models that use get / list endpoints, its child resume models' `sdk` attribute returns None. It causes functions like `get_full_set` and `get_full_card` to raise AttributeError.

This pull request includes a change to the `_from_dict` method in the `src/tcgdexsdk/utils.py` file. The change ensures that the `sdk` attribute is properly set for all child models within the main model.

* [`src/tcgdexsdk/utils.py`](diffhunk://#diff-0ee6d0aea78bab3abfb8621b9589e61d0ea0ecdc759948594161e8863d044694R34-R42): Modified the `_from_dict` method to recursively set the `sdk` attribute for child models and lists of models.