### PR TITLE
Fix whitespace issue in Endpoint.get URL

### DIFF
--- a/src/tcgdexsdk/endpoints/Endpoint.py
+++ b/src/tcgdexsdk/endpoints/Endpoint.py
@@ -26,7 +26,7 @@ class Endpoint(Generic[Item, ListModel]):
         self.endpoint = endpoint
 
     async def get(self, id: str) -> Optional[Item]:
-        return fetch(self.tcgdex, f"https://api.tcgdex.net/v2/{self.tcgdex.language}/{self.endpoint}/{id}", self.item_model)
+        return fetch(self.tcgdex, f"https://api.tcgdex.net/v2/{self.tcgdex.language}/{self.endpoint}/{id.replace(' ', '%20')}", self.item_model)
 
     async def list(self, query: Optional[Query] = None) -> List[ListModel]:
         return fetch_list(self.tcgdex, f"https://api.tcgdex.net/v2/{self.tcgdex.language}/{self.endpoint}", self.list_model)


### PR DESCRIPTION
When trying out mentioned examples in the ReadME.md, like `await tcgdex.illustrator.get('tetsuya koizumi')`, the following error gets raised: `http.client.InvalidURL: URL can't contain control characters.`.

This is because whitespace characters are never replaced with `%20` in the `Endpoint.get()` method. 
This PR solves this issue and `await tcgdex.illustrator.get('tetsuya koizumi')` returns the expected result.