### PR TITLE
fix: use TCGdex.URI to build url

### DIFF
--- a/src/tcgdexsdk/endpoints/Endpoint.py
+++ b/src/tcgdexsdk/endpoints/Endpoint.py
@@ -26,7 +26,7 @@ class Endpoint(Generic[Item, ListModel]):
         self.endpoint = endpoint
 
     async def get(self, id: str) -> Optional[Item]:
-        return fetch(self.tcgdex, f"https://api.tcgdex.net/v2/{self.tcgdex.language}/{self.endpoint}/{id.replace(' ', '%20')}", self.item_model)
+        return fetch(self.tcgdex, f"{self.tcgdex.URI}/{self.tcgdex.language}/{self.endpoint}/{id.replace(' ', '%20')}", self.item_model)
 
     async def list(self, query: Optional[Query] = None) -> List[ListModel]:
-        return fetch_list(self.tcgdex, f"https://api.tcgdex.net/v2/{self.tcgdex.language}/{self.endpoint}", self.list_model)
+        return fetch_list(self.tcgdex, f"{self.tcgdex.URI}/{self.tcgdex.language}/{self.endpoint}", self.list_model)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 from typing import Callable
 
 import vcr
@@ -21,6 +22,16 @@ class APITest(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.api = TCGdex(Language.EN)
 
+    @patch("tcgdexsdk.endpoints.Endpoint.fetch")
+    @patch("tcgdexsdk.endpoints.Endpoint.fetch_list")
+    async def test_uri(self, mock_fetch_list, mock_fetch):
+        api = TCGdex(Language.EN)
+        api.URI = "http://localhost:3000/v2"
+        await api.card.get("swsh1-136")
+        mock_fetch.assert_called_once_with(api, "http://localhost:3000/v2/en/cards/swsh1-136", Card)
+        await api.card.list()
+        mock_fetch_list.assert_called_once_with(api, "http://localhost:3000/v2/en/cards", CardResume)
+
     @_use_cassette
     async def test_fr(self):
         tcg = TCGdex(Language.FR)
@@ -29,7 +40,6 @@ class APITest(unittest.IsolatedAsyncioTestCase):
         tcg2 = TCGdex('fr')
         res = await tcg2.card.get('swsh3-136')
         self.assertEqual(res.name, 'Fouinar')
-
 
     @_use_cassette
     async def test_card_resume(self):


### PR DESCRIPTION
previously TCGdex.URI was completely unused. this pr allows modifying this variable to point custom host.

```
from tcgdexsdk import TCGdex

TCGdex.URI = "http://localhost:3000/v2"  # modify host for every subsequent fetch/fecth_list calls

tcgdex = TCGdex("en")
tcgdex.URI = "http://localhost:3000/v2"  # modify only for this tcgdex object
```