### PR TITLE
fix typos

### DIFF
--- a/src/tcgdexsdk/models/Card.py
+++ b/src/tcgdexsdk/models/Card.py
@@ -31,13 +31,13 @@ class Card(Model):
     """The card possible variants"""
     set: SetResume
     """Resume of the set the card belongs to"""
-    dexIDs: Optional[List[int]]
+    dexId: Optional[List[int]]
     """the Pokémon Pokédex IDs (multiple if multiple pokémon appears on the card)"""
     hp: Optional[int]
     """HP of the pokemon"""
     types: Optional[List[str]]
     """Types of the pokemon (multiple because some have multiple in the older sets)"""
-    evolvesFrom: Optional[str]
+    evolveFrom: Optional[str]
     """Name of the pokemon this one evolves from"""
     description: Optional[str]
     """the Pokémon Pokédex like description"""


### PR DESCRIPTION
Fixes #17

Double-checked all the fields in `Card`, will look for similar errors on other types later.

Side note: Python 3.8 support was dropped last October, and this year 3.9 will also be dropped. Shall i also update the project's metadata to bump the required version to `3.10`? It would also allow using newer syntax, like `list[int] | None` instead of requiring imports of `List` and `Optional` from the `typing` module