### PR TITLE
feat(set): add new abbreviations field with the supported languages

### DIFF
--- a/src/tcgdexsdk/models/Set.py
+++ b/src/tcgdexsdk/models/Set.py
@@ -7,7 +7,7 @@ from tcgdexsdk.enums import Extension
 from tcgdexsdk.models.CardResume import CardResume
 from tcgdexsdk.models.Model import Model
 from tcgdexsdk.models.SerieResume import SerieResume
-from tcgdexsdk.models.subs import Booster, Legal, SetCardCountResume
+from tcgdexsdk.models.subs import Booster, Legal, SetAbbreviations, SetCardCountResume
 
 
 @dataclass
@@ -37,6 +37,8 @@ class Set(Model):
     """the cards contained in this set"""
     boosters: Optional[List[Booster]]
     """The list of booster the set has"""
+    abbreviations: Optional[SetAbbreviations]
+    """The set abbreviations (official and in other languages if available)"""
 
     def get_logo_url(self, extension: Union[str, Extension]) -> Optional[str]:
         """
@@ -65,9 +67,7 @@ class Set(Model):
         if self.symbol:
             return f"{self.symbol}.{extension}"
 
-    def get_symbol(
-        self, format: Union[str, Extension]
-    ) -> Optional[HTTPResponse]:
+    def get_symbol(self, format: Union[str, Extension]) -> Optional[HTTPResponse]:
         """
         Get the symbol buffer
         @param format: the image format

--- a/src/tcgdexsdk/models/subs.py
+++ b/src/tcgdexsdk/models/subs.py
@@ -93,7 +93,8 @@ class SetCardCount:
     """number of cards having an holo version"""
     firstEd: Optional[int]
     """Number of possible cards"""
-    
+
+
 @dataclass
 class Booster:
     id: str
@@ -111,3 +112,45 @@ class SetCardCountResume:
     """total of number of cards"""
     official: int
     """number of cards officialy (on the bottom of each cards)"""
+
+
+@dataclass
+class SetAbbreviations:
+    """Set abbreviations"""
+
+    official: Optional[str]
+    """Official abbreviation acronym used on the cards (English version)"""
+    fr: Optional[str]
+    """French abbreviation acronym used on the cards"""
+    es: Optional[str]
+    """Spanish abbreviation acronym used on the cards"""
+    es_mx: Optional[str]
+    """Spanish (Mexico) abbreviation acronym used on the cards"""
+    it: Optional[str]
+    """Italian abbreviation acronym used on the cards"""
+    pt: Optional[str]
+    """Portuguese abbreviation acronym used on the cards"""
+    pt_br: Optional[str]
+    """Portuguese (Brazil) abbreviation acronym used on the cards"""
+    pt_pt: Optional[str]
+    """Portuguese (Portugal) abbreviation acronym used on the cards"""
+    de: Optional[str]
+    """German abbreviation acronym used on the cards"""
+    nl: Optional[str]
+    """Dutch abbreviation acronym used on the cards"""
+    pl: Optional[str]
+    """Polish abbreviation acronym used on the cards"""
+    ru: Optional[str]
+    """Russian abbreviation acronym used on the cards"""
+    ja: Optional[str]
+    """Japanese abbreviation acronym used on the cards"""
+    ko: Optional[str]
+    """Korean abbreviation acronym used on the cards"""
+    zh_tw: Optional[str]
+    """Chinese (Taiwan) abbreviation acronym used on the cards"""
+    id: Optional[str]
+    """Indonesian abbreviation acronym used on the cards"""
+    th: Optional[str]
+    """Thai abbreviation acronym used on the cards"""
+    zh_cn: Optional[str]
+    """Chinese (China) abbreviation acronym used on the cards"""


### PR DESCRIPTION

Fixes #21 

I am using the SDK and needing the `abbreviations.official` value, just added it according to the latest model in the API:

https://github.com/tcgdex/cards-database/blob/master/interfaces.d.ts#L144